### PR TITLE
Allow values to be False

### DIFF
--- a/ostruct/openstruct.py
+++ b/ostruct/openstruct.py
@@ -57,7 +57,7 @@ class OpenStruct(MutableMapping):
         self.__dict__.__delitem__(key)
 
     def __getattr__(self, key):
-        if not self.__dict__.get(key):
+        if self.__dict__.get(key) is None:
             self.__dict__[key] = self.__class__()
 
         return self.__dict__[key]

--- a/tests/test_openstruct.py
+++ b/tests/test_openstruct.py
@@ -19,6 +19,12 @@ def test_empty_struct():
     else:
         assert False
 
+def test_booleans():
+    o = OpenStruct(true=True, false=False)
+
+    assert o.true == True
+    assert o.false == False
+    assert isinstance(o.none, OpenStruct)
 
 def test_shallow_struct():
     o = OpenStruct()

--- a/tests/test_openstruct.py
+++ b/tests/test_openstruct.py
@@ -19,12 +19,14 @@ def test_empty_struct():
     else:
         assert False
 
+
 def test_booleans():
     o = OpenStruct(true=True, false=False)
 
-    assert o.true == True
-    assert o.false == False
+    assert o.true is True
+    assert o.false is False
     assert isinstance(o.none, OpenStruct)
+
 
 def test_shallow_struct():
     o = OpenStruct()


### PR DESCRIPTION
Right now supplying a `False` value has it ignored and replaced as if it was `None`.

This patch makes it possible to have a `False` value stay as-is. This is important for some applications where `False` is used as a value.
