### PR TITLE
Ensure that list-items that are `dict(s)` are [also] converted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /.cache
 /.coverage
 /.pytest_cache
+/.venv
 /htmlcov

--- a/ostruct/openstruct.py
+++ b/ostruct/openstruct.py
@@ -1,9 +1,9 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class OpenStruct(MutableMapping):
     """OpenStruct, the flexible data structure."""
-    def __init__(self, clone=None, **kwargs):
+    def __init__(self, clone=None, dict_convert=False, **kwargs):
         super(OpenStruct, self).__init__()
 
         if isinstance(clone, OpenStruct):
@@ -14,14 +14,16 @@ class OpenStruct(MutableMapping):
             raise TypeError('Type to be cloned is not supported.')
 
         for key, value in kwargs.items():
-            self.__dict__[key] = self._convert(value)
+            self.__dict__[key] = self._convert(value, dict_convert)
 
     @classmethod
-    def _convert(cls, value):
-        if isinstance(value, (list, tuple)):
+    def _convert(cls, value, dict_convert=False):
+        if dict_convert and isinstance(value, dict):
+            return cls(**value)
+        elif isinstance(value, (list, tuple)):
             dictionaries = []
             for item in value:
-                dictionaries.append(cls._convert(item))
+                dictionaries.append(cls._convert(item, dict_convert))
 
             if isinstance(value, tuple):
                 dictionaries = tuple(dictionaries)

--- a/tests/test_openstruct.py
+++ b/tests/test_openstruct.py
@@ -1,6 +1,15 @@
-import pytest
-from ostruct import OpenStruct
 import pickle
+import pytest
+
+from ostruct import OpenStruct
+
+
+class OpenStructChild1(OpenStruct):
+    pass
+
+
+class OpenStructChild2(OpenStruct):
+    pass
 
 
 def test_empty_struct():
@@ -61,8 +70,16 @@ def test_nested_struct():
 
 
 def test_constructor_clone():
-    o = OpenStruct(a=1, b=2, c=4)
-    assert o == {'a': 1, 'b': 2, 'c': 4}
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4
+    )
+    assert o == {
+        'a': 1,
+        'b': 2,
+        'c': 4,
+    }
 
     a = OpenStruct(o)
     assert o == a
@@ -77,27 +94,34 @@ def test_constructor_clone():
     assert o == d
 
 
-@pytest.mark.parametrize("kwargs,expected,expected2", [
-    ({}, "{}", None),
-
-    ({'a': 1}, "{'a': 1}", None),
-
-    ({'a': 1, 'b': 'Hello'},
-     "{'a': 1, 'b': 'Hello'}",
-     "{'b': 'Hello', 'a': 1}"),
-
-    ({'a': 1, 'b': {'b1': 1e100}},
-     "{'a': 1, 'b': {'b1': 1e+100}}",
-     "{'b': {'b1': 1e+100}, 'a': 1}"),
+@pytest.mark.parametrize('kwargs,expected,expected2', [
+    (
+        {},
+        '{}',
+        None,
+    ), (
+        {'a': 1},
+        "{'a': 1}",
+        None,
+    ), (
+        {'a': 1, 'b': 'Hello'},
+        "{'a': 1, 'b': 'Hello'}",
+        "{'b': 'Hello', 'a': 1}",
+    ), (
+        {'a': 1, 'b': {'b1': 1e100}},
+        "{'a': 1, 'b': {'b1': 1e+100}}",
+        "{'b': {'b1': 1e+100}, 'a': 1}",
+    ),
 ])
-def test__repr(kwargs, expected, expected2):
+def test_repr(kwargs, expected, expected2):
     o = OpenStruct(**kwargs)
     assert str(o) == expected or str(o) == expected2
 
 
-@pytest.mark.parametrize("value,expected", [
+@pytest.mark.parametrize('value,expected', [
     (1, 1),
     ('Hello', 'Hello'),
+    ([], []),
     ((), ()),
     ((1, 2), (1, 2)),
     (('Hello', 'World'), ('Hello', 'World')),
@@ -115,11 +139,42 @@ def test_convert(value, expected):
     assert OpenStruct._convert(value) == expected
 
 
-@pytest.mark.parametrize("value", [
+@pytest.mark.parametrize('value,expected', [
+    (1, 1),
+    ('Hello', 'Hello'),
+    ([], []),
+    ((), ()),
+    ((1, 2), (1, 2)),
+    (('Hello', 'World'), ('Hello', 'World')),
+    ([], []),
+    ([1, 2], [1, 2]),
+    (['Hello', 'World'], ['Hello', 'World']),
+    ({'a': 1, 'b': 2}, OpenStruct({'a': 1, 'b': 2})),
+    (({'a': 1, 'b': 2}, {'c': 3}), (
+        OpenStruct({'a': 1, 'b': 2}),
+        OpenStruct({'c': 3}))),
+    ([{'a': 1, 'b': 2}, {'c': 3}], [
+        OpenStruct({'a': 1, 'b': 2}),
+        OpenStruct({'c': 3})]),
+    (OpenStruct({'a': 1, 'b': 2}), OpenStruct({'a': 1, 'b': 2})),
+    ((OpenStruct({'a': 1, 'b': 2})), (OpenStruct({'a': 1, 'b': 2}))),
+    ([OpenStruct({'a': 1, 'b': 2})], [OpenStruct({'a': 1, 'b': 2})]),
+])
+def test_convert_with_dict_convert(value, expected):
+    assert OpenStruct._convert(value, dict_convert=True) == expected
+
+
+@pytest.mark.parametrize('value', [
     1,
-    1.2,
-    (1, 2, 3),
-    [{'a': 1, 'b': 2, 'c': 4}],
+    1.2, (
+        1,
+        2,
+        3
+    ), [{
+        'a': 1,
+        'b': 2,
+        'c': 4,
+    }],
     'Hello',
     lambda x: x**2
 ])
@@ -157,19 +212,34 @@ def test_comparisons():
 
 
 def test_iter():
-    keys = []
-    o = OpenStruct(a=1, b=2, c=4, d=8)
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4,
+        d=8
+    )
 
+    keys = []
     for key in o:
         keys.append(key)
 
-    assert sorted(keys) == sorted(['a', 'b', 'c', 'd'])
+    assert sorted(keys) == sorted([
+        'a',
+        'b',
+        'c',
+        'd',
+    ])
 
 
 def test_iteritems():
-    s = 0
-    o = OpenStruct(a=1, b=2, c=4, d=8)
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4,
+        d=8
+    )
 
+    s = 0
     for key, value in o.iteritems():
         s += value
 
@@ -177,9 +247,14 @@ def test_iteritems():
 
 
 def test_items():
-    s = 0
-    o = OpenStruct(a=1, b=2, c=4, d=8)
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4,
+        d=8
+    )
 
+    s = 0
     for key, value in o.items():
         s += value
 
@@ -190,18 +265,28 @@ def test_keys():
     o = OpenStruct()
     assert len(o.keys()) == 0
 
-    o = OpenStruct(a=1, b=2, c=4)
-    assert sorted(o.keys()) == sorted(['a', 'b', 'c'])
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4
+    )
+    assert sorted(o.keys()) == sorted([
+        'a',
+        'b',
+        'c',
+    ])
 
 
 def test_set_get_item():
     o = OpenStruct()
     o['a'] = 10
+
     assert o['a'] == 10
     assert o.a == 10
 
     o = OpenStruct()
     o['a']['b']['c'] = 10
+
     assert o['a']['b']['c'] == 10
     assert o['a']['b'] == {'c': 10}
     assert o['a'] == {'b': {'c': 10}}
@@ -209,7 +294,11 @@ def test_set_get_item():
 
 
 def test_delete_attr():
-    o = OpenStruct(a=1, b=2, c=4)
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4
+    )
 
     del o.b
     assert o == {'a': 1, 'c': 4}
@@ -217,15 +306,23 @@ def test_delete_attr():
     o.b.d.e = 10
 
     del o.b.d
-    assert o == {'a': 1, 'c': 4, 'b': {}}
+    assert o == {
+        'a': 1,
+        'c': 4,
+        'b': {},
+    }
 
     del o
     with pytest.raises(NameError):
-        assert o  # NoQA
+        assert o  # noqa
 
 
 def test_delete_item():
-    o = OpenStruct(a=1, b=2, c=4)
+    o = OpenStruct(
+        a=1,
+        b=2,
+        c=4
+    )
 
     del o['b']
     assert o == {'a': 1, 'c': 4}
@@ -233,26 +330,39 @@ def test_delete_item():
     o.b.d.e = 10
 
     del o['b']['d']
-    assert o == {'a': 1, 'c': 4, 'b': {}}
+    assert o == {
+        'a': 1,
+        'c': 4,
+        'b': {},
+    }
 
 
-@pytest.mark.parametrize("value,expected", [
+@pytest.mark.parametrize('value,expected', [
     (None, 0),
-    ({'a': 1, 'b': 2, 'c': 4}, 3),
-    (OpenStruct(a=1, b=2, c=4, d=8), 4),
+    ({
+        'a': 1,
+        'b': 2,
+        'c': 4
+    }, 3),
+    (OpenStruct(
+        a=1,
+        b=2,
+        c=4,
+        d=8
+    ), 4),
 ])
 def test_len(value, expected):
-    o = OpenStruct(value)
-    assert len(o) == expected
+    assert len(OpenStruct(value)) == expected
 
 
 def test_types():
-    d = {'a': 1, 'b': 2, 'c': 3}
+    d = {
+        'a': 1,
+        'b': '2',
+        'c': 3,
+    }
 
-    o = OpenStruct(
-        a=d,
-        b=OpenStruct(d)
-    )
+    o = OpenStruct(a=d, b=OpenStruct(d))
     o.n.o = 1
     o.p = d
     o.q = OpenStruct(d)
@@ -266,53 +376,116 @@ def test_types():
     assert isinstance(o.q, OpenStruct)
 
 
+def test_types_with_dict_convert():
+    d = {
+        'a': 1,
+        'b': '2',
+        'c': True,
+    }
+
+    o = OpenStruct(dict_convert=True, d=d)
+
+    assert isinstance(o, OpenStruct)
+    assert isinstance(o.d, OpenStruct)
+    assert isinstance(o.d.a, int)
+    assert isinstance(o.d.b, str)
+    assert isinstance(o.d.c, bool)
+
+
 def test_inheritance_types():
-    class TestOpenStruct(OpenStruct):
-        pass
+    d = {
+        'a': 1,
+        'b': '2',
+        'c': True,
+    }
 
-    class AnotherOpenStruct(OpenStruct):
-        pass
-
-    d = {'a': 1, 'b': 2, 'c': 3}
-
-    o = TestOpenStruct(
+    o = OpenStructChild2(
         a=d,
         b=OpenStruct(d),
-        c=TestOpenStruct(d),
-        d=AnotherOpenStruct(d),
-        e=TestOpenStruct(AnotherOpenStruct(d))
+        c=OpenStructChild2(d),
+        d=OpenStructChild1(d),
+        e=OpenStructChild2(OpenStructChild1(d))
     )
     o.n.o = 1
     o.p = d
     o.q = OpenStruct(d)
-    o.r = TestOpenStruct(d)
-    o.s = AnotherOpenStruct(d)
-    o.t = TestOpenStruct(AnotherOpenStruct(d))
+    o.r = OpenStructChild2(d)
+    o.s = OpenStructChild1(d)
+    o.t = OpenStructChild2(OpenStructChild1(d))
 
-    assert isinstance(o, TestOpenStruct)
+    assert isinstance(o, OpenStructChild2)
     assert isinstance(o.a, dict)
-    assert not isinstance(o.b, TestOpenStruct)
-    assert isinstance(o.c, TestOpenStruct)
-    assert isinstance(o.d, AnotherOpenStruct)
-    assert isinstance(o.e, TestOpenStruct)
-    assert isinstance(o.n, TestOpenStruct)
+    assert not isinstance(o.b, OpenStructChild2)
+    assert isinstance(o.c, OpenStructChild2)
+    assert isinstance(o.d, OpenStructChild1)
+    assert isinstance(o.e, OpenStructChild2)
+    assert isinstance(o.n, OpenStructChild2)
     assert isinstance(o.n.o, int)
     assert isinstance(o.p, dict)
-    assert not isinstance(o.q, TestOpenStruct)
-    assert isinstance(o.r, TestOpenStruct)
-    assert isinstance(o.s, AnotherOpenStruct)
-    assert isinstance(o.t, TestOpenStruct)
+    assert not isinstance(o.q, OpenStructChild2)
+    assert isinstance(o.r, OpenStructChild2)
+    assert isinstance(o.s, OpenStructChild1)
+    assert isinstance(o.t, OpenStructChild2)
 
 
-@pytest.mark.parametrize("struct", [
-    (OpenStruct(A=1, B=2, C=3)),
-    (OpenStruct(A=1, B=2, C=[1, 2, 3, 4])),
-    (OpenStruct(A=1, B=2, C=[1, 2, [3, 4]])),
-    (OpenStruct(A=1, B=2, C=OpenStruct(x=1, y=2))),
-    (OpenStruct(A="string1", B="string2",
-                C=OpenStruct(AA=OpenStruct(AAA=1, BBB="inception"))))
+def test_inheritance_types_with_dict_convert():
+    d = {
+        'a': 1,
+        'b': '2',
+        'c': True,
+    }
+
+    o = OpenStructChild2(
+        dict_convert=True,
+        a=OpenStructChild1(d),
+        b=OpenStruct(d),
+        c=OpenStructChild2(d),
+        d=d,
+        e=OpenStructChild2(OpenStructChild1(d))
+    )
+
+    assert isinstance(o, OpenStructChild2)
+    assert isinstance(o.a, OpenStructChild1)
+    assert isinstance(o.b, OpenStruct)
+    assert isinstance(o.c, OpenStructChild2)
+    assert isinstance(o.d, OpenStructChild2)
+    assert isinstance(o.e, OpenStructChild2)
+    assert isinstance(o.d.a, int)
+    assert isinstance(o.d.b, str)
+    assert isinstance(o.d.c, bool)
+
+
+@pytest.mark.parametrize('struct', [
+    (
+        OpenStruct(
+            A=1,
+            B=2,
+            C=3
+        )
+    ), (
+        OpenStruct(
+            A=1,
+            B=2,
+            C=[1, 2, 3, 4])
+    ), (
+        OpenStruct(
+            A=1,
+            B=2,
+            C=[1, 2, [3, 4]])
+    ), (
+        OpenStruct(
+            A=1,
+            B=2,
+            C=OpenStruct(x=1, y=2))
+    ), (
+        OpenStruct(
+            A='string1',
+            B='string2',
+            C=OpenStruct(AA=OpenStruct(AAA=1, BBB='inception'))
+        )
+    )
 ])
 def test_pickling(struct):
-    bin = pickle.dumps(struct)
-    loaded = pickle.loads(bin)
+    dumped = pickle.dumps(struct)
+    loaded = pickle.loads(dumped)
     assert struct == loaded


### PR DESCRIPTION
I have been running this as a monkey-patch for a while, but wanted to push this upstream.

This change ensures that `list`-items that are `dict(s)` are [also] converted during the init-process and bumps the version to 3.1.0 as this _could_ be a breaking change.