### PR TITLE
Fixed warning about importing from collections instead of collections.abc

### DIFF
--- a/ostruct/openstruct.py
+++ b/ostruct/openstruct.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class OpenStruct(MutableMapping):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py36, py37, pypy, pypy3
-
-[testenv:pypy3]
-basepython = pypy
+envlist = py{27,34,35,36,37,38,py2,py3}
 
 [testenv]
 basepython =
@@ -11,6 +8,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy2: pypy
     pypy3: pypy3
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
-envlist = py{27,34,35,36,37,38,py2,py3}
+envlist = py{34,35,36,37,38,py3}
 
 [testenv]
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
-    pypy2: pypy
     pypy3: pypy3
 
 commands = py.test -v --cov


### PR DESCRIPTION
Also added python 3.8 to test envs since this is the Python version where you can't import `MutableMapping` from collections anymore. 